### PR TITLE
chore: refactor away from ILogger + complete DI

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -61,7 +61,7 @@ CADViewer implements CAD viewing, markup and collaboration on the NextCloud plat
     <screenshot small-thumbnail="https://cadviewer.com/images/cadviewer/nextcloud/nextcloud_small_02.png">https://cadviewer.com/images/cadviewer/nextcloud/nextcloud_small_02.png</screenshot>
     <screenshot>https://cadviewer.com/images/cadviewer/nextcloud/nextcloud_big_01.png</screenshot>    
     <dependencies>
-        <nextcloud min-version="25" max-version="30"/>
+        <nextcloud min-version="25" max-version="31"/>
     </dependencies>
     <settings>
         <admin>OCA\Cadviewer\AdminSettings</admin>

--- a/lib/AdminSettings.php
+++ b/lib/AdminSettings.php
@@ -1,22 +1,21 @@
 <?php
+
 namespace OCA\Cadviewer;
 
 use OCP\Settings\ISettings;
 
-use OCA\Cadviewer\AppInfo\Application;
 use OCA\Cadviewer\Controller\SettingsController;
 
 
 class AdminSettings implements ISettings {
 
-    public function __construct() {
+    public function __construct(
+        private SettingsController $settings,
+    ) {
     }
 
-
     public function getForm() {
-        $app = \OC::$server->query(Application::class);
-        $container = $app->getContainer();
-        $response = $container->query(SettingsController::class)->index();
+        $response = $settings->index();
         return $response;
     }
 

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -4,7 +4,7 @@ namespace OCA\Cadviewer;
 
 
 use OCP\IConfig;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Application configutarion
@@ -94,12 +94,11 @@ class AppConfig {
     /** 
      * @param string $AppName - application name
      */
-    public function __construct($AppName) {
+    public function __construct($AppName, LoggerInterface $logger, IConfig $config) {
 
         $this->appName = $AppName;
-
-        $this->config = \OC::$server->getConfig();
-        $this->logger = \OC::$server->getLogger();
+        $this->config = $config;
+        $this->logger = $logger;
     }
 
     public function GetSystemValue($key, $system = false) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -4,86 +4,48 @@ declare(strict_types=1);
 
 namespace OCA\Cadviewer\AppInfo;
 
+use OCA\Cadviewer\Listeners\CSPListener;
+use OCA\Cadviewer\Listeners\LoadScriptsListener;
+use OCA\Cadviewer\AppConfig;
+use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
-use OCA\Files\Event\LoadAdditionalScriptsEvent;
 
-
-use OCA\Cadviewer\Controller\SettingsController;
-use OCA\Cadviewer\Listeners\CSPListener;
-use OCA\Cadviewer\Listeners\LoadScriptsListener;
-use OCA\Cadviewer\AppConfig;
-
-use OC\Files\Filesystem;
-
-use Psr\Container\ContainerInterface;
-use OCP\Util;
-
-
+/**
+ * Class Application
+ *
+ * @package OCA\Cadviewer\AppInfo
+ */
 class Application extends App implements IBootstrap {
+    public const APP_NAME = 'cadviewer';
 
     /**
      * Application configuration
      *
      * @var AppConfig
      */
-    public $appConfig;
-
-	public const APP_NAME = 'cadviewer';
-
-    public function __construct(array $params  = []) {
-        parent::__construct(self::APP_NAME, $params);
-
+    public AppConfig $appConfig;
+    
+    /**
+     * Application constructor.
+     *
+     * @param array $urlParams
+     */    
+    public function __construct(array $urlParams = []) {
+        parent::__construct(self::APP_NAME, $urlParams);
+        
         $this->appConfig = new AppConfig(self::APP_NAME);
     }
 
     public function register(IRegistrationContext $context): void {
-        
-        $context->registerService("L10N", function (ContainerInterface $c) {
-            return $c->get("ServerContainer")->getL10N($c->get("AppName"));
-        });
-
-        $context->registerService("RootStorage", function (ContainerInterface $c) {
-            return $c->get("ServerContainer")->getRootFolder();
-        });
-
-        $context->registerService("UserSession", function (ContainerInterface $c) {
-            return $c->get("ServerContainer")->getUserSession();
-        });
-
-        $context->registerService("UserManager", function (ContainerInterface $c) {
-            return $c->get("ServerContainer")->getUserManager();
-        });
-
-        $context->registerService("Logger", function (ContainerInterface $c) {
-            return $c->get("ServerContainer")->getLogger();
-        });
-
-        $context->registerService("URLGenerator", function (ContainerInterface $c) {
-            return $c->get("ServerContainer")->getURLGenerator();
-        });
-
-        // Controllers
-        $context->registerService("SettingsController", function (ContainerInterface $c) {
-            return new SettingsController(
-                $c->get("AppName"),
-                $c->get("Request"),
-                $c->get("URLGenerator"),
-                $c->get("L10N"),
-                $c->get("Logger"),
-                $this->appConfig
-            );
-        });
-
-    
 		$context->registerEventListener(AddContentSecurityPolicyEvent::class, CSPListener::class);
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadScriptsListener::class);
     }
 
     public function boot(IBootContext $context): void {
-        
+        // ...
     }
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -1,44 +1,28 @@
 <?php
 namespace OCA\Cadviewer\Controller;
 
+use OCA\Cadviewer\AppConfig;
+
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
-
-
-use OCA\Cadviewer\AppConfig;
+use Psr\Log\LoggerInterface;
 
 class SettingsController extends Controller {
 
-    private $trans;
-    private $logger;
-    private $urlGenerator;
-
-    /**
-     * Application configuration
-     *
-     * @var AppConfig
-     */
-    private $config;
-
-    public function __construct($AppName,
-                                    IRequest $request,
-                                    IURLGenerator $urlGenerator,
-                                    IL10N $trans,
-                                    ILogger $logger,
-                                    AppConfig $config
-                                    ) {
+    public function __construct(
+	    $AppName,
+        IRequest $request,
+        private IURLGenerator $urlGenerator,
+        private IL10N $trans,
+        private LoggerInterface $logger,
+        private AppConfig $config,
+    ) {
         parent::__construct($AppName, $request);
-
-        $this->urlGenerator = $urlGenerator;
-        $this->trans = $trans;
-        $this->logger = $logger;
-        $this->config = $config;
     }
 
     /**


### PR DESCRIPTION
Fixes #106 
Fixes #107

Nextcloud community developer here. Not a CADViewer user so some testers are needed, but this PR should implement the changes required to bring the back-end up-to-date enough work with Nextcloud Server v31.

Changes:

- migrate from deprecated ILogger to PSR LoggerInterface
- use dependency injection (it was mostly already being used and just need a couple missing spots)
- remove no longer needed code in `Application.php` (due to the use of DI throughout)